### PR TITLE
fix: cycles values are always zero

### DIFF
--- a/tools/llvm-mc-bench/BenchmarkResult.hpp
+++ b/tools/llvm-mc-bench/BenchmarkResult.hpp
@@ -7,6 +7,7 @@
 
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Error.h"
 #include "llvm/Support/raw_ostream.h"
 
 #include <cstdint>
@@ -33,12 +34,12 @@ struct Measurement {
   uint64_t noiseInstructions;
   uint64_t noiseNumRuns;
 
-  void exportBinary(std::filesystem::path path, llvm::StringRef source,
-                    llvm::ArrayRef<BenchmarkResult> noise,
-                    llvm::ArrayRef<BenchmarkResult> workload);
-  void exportJSON(std::filesystem::path path, llvm::StringRef source,
-                  llvm::ArrayRef<BenchmarkResult> noise,
-                  llvm::ArrayRef<BenchmarkResult> workload);
+  llvm::Error exportBinary(std::filesystem::path path, llvm::StringRef source,
+                           llvm::ArrayRef<BenchmarkResult> noise,
+                           llvm::ArrayRef<BenchmarkResult> workload);
+  llvm::Error exportJSON(std::filesystem::path path, llvm::StringRef source,
+                         llvm::ArrayRef<BenchmarkResult> noise,
+                         llvm::ArrayRef<BenchmarkResult> workload);
 };
 
 /// BenchmarkResult is a result of a single harrness run, whether it is a noise

--- a/tools/llvm-mc-bench/counters.cpp
+++ b/tools/llvm-mc-bench/counters.cpp
@@ -21,7 +21,7 @@
 namespace llvm_ml {
 class CountersContext {
 public:
-  CountersContext(const CountersCb &cb) : mCB(cb) {
+  CountersContext(CountersCb cb) : mCB(cb) {
     pmu::Builder builder;
     builder.add_counter(pmu::CounterKind::Cycles)
         .add_counter(pmu::CounterKind::Instructions)
@@ -38,19 +38,19 @@ public:
     llvm::SmallVector<CounterValue> counters;
 
     for (auto value : *mCounters) {
-      if (value.name == "cycles") {
+      if (value.name.starts_with("cycles")) {
         counters.push_back(
             CounterValue{.type = Counter::Cycles,
                          .value = static_cast<size_t>(value.value)});
-      } else if (value.name == "instructions") {
+      } else if (value.name.starts_with("instructions")) {
         counters.push_back(
             CounterValue{.type = Counter::Instructions,
                          .value = static_cast<size_t>(value.value)});
-      } else if (value.name == "cache_misses") {
+      } else if (value.name.starts_with("cache_misses")) {
         counters.push_back(
             CounterValue{.type = Counter::CacheMisses,
                          .value = static_cast<size_t>(value.value)});
-      } else if (value.name == "SW:context_switches") {
+      } else if (value.name.starts_with("SW:context_switches")) {
         counters.push_back(
             CounterValue{.type = Counter::ContextSwitches,
                          .value = static_cast<size_t>(value.value)});
@@ -69,8 +69,8 @@ private:
 
 void flushCounters(CountersContext *ctx) { ctx->flush(); }
 
-std::shared_ptr<CountersContext> createCounters(const CountersCb &cb) {
-  return std::make_shared<CountersContext>(cb);
+std::shared_ptr<CountersContext> createCounters(CountersCb cb) {
+  return std::make_shared<CountersContext>(std::move(cb));
 }
 
 } // namespace llvm_ml

--- a/tools/llvm-mc-bench/counters.hpp
+++ b/tools/llvm-mc-bench/counters.hpp
@@ -30,7 +30,7 @@ using CountersCb = std::function<void(llvm::ArrayRef<CounterValue>)>;
 class CountersContext;
 
 void flushCounters(CountersContext *ctx);
-std::shared_ptr<CountersContext> createCounters(const CountersCb &cb);
+std::shared_ptr<CountersContext> createCounters(CountersCb cb);
 } // namespace llvm_ml
 
 extern "C" {

--- a/tools/llvm-mc-bench/llvm-mc-bench.cpp
+++ b/tools/llvm-mc-bench/llvm-mc-bench.cpp
@@ -194,13 +194,11 @@ llvm::Error runSingleFile(fs::path input, fs::path output,
   llvm_ml::Measurement m = *minWorkload - *minNoise;
 
   if (ReadableJSON) {
-    m.exportJSON(output, (*buffer)->getBuffer(), noiseResults, workloadResults);
-  } else {
-    m.exportBinary(output, (*buffer)->getBuffer(), noiseResults,
-                   workloadResults);
+    return m.exportJSON(output, (*buffer)->getBuffer(), noiseResults,
+                        workloadResults);
   }
-
-  return Error::success();
+  return m.exportBinary(output, (*buffer)->getBuffer(), noiseResults,
+                        workloadResults);
 }
 
 int runBatch(fs::path input, fs::path output, const Target *target) {


### PR DESCRIPTION
Due to a bug in libpmu comparison of strings was failing. As a workaround use .starts_with to collect counters. Tracker for original issue in libpmu: https://github.com/perf-toolbox/libpmu/issues/1

Also fixes #6 which was caused by incorrect error handling.